### PR TITLE
Propagate context through unit of work and event publishing

### DIFF
--- a/internal/adapters/out/postgres/eventrepo/repository.go
+++ b/internal/adapters/out/postgres/eventrepo/repository.go
@@ -87,8 +87,7 @@ func (r *Repository) Publish(ctx context.Context, events ...ddd.DomainEvent) err
 }
 
 // PublishDomainEvents реализует интерфейс для use cases
-func (r *Repository) PublishDomainEvents(events []ddd.DomainEvent) error {
-	ctx := context.Background()
+func (r *Repository) PublishDomainEvents(ctx context.Context, events []ddd.DomainEvent) error {
 	return r.Publish(ctx, events...)
 }
 

--- a/internal/adapters/out/postgres/unit_of_work.go
+++ b/internal/adapters/out/postgres/unit_of_work.go
@@ -95,9 +95,7 @@ func (u *UnitOfWork) Commit(ctx context.Context) error {
 }
 
 // Execute выполняет операцию в транзакции
-func (u *UnitOfWork) Execute(fn func() error) error {
-	ctx := context.Background()
-
+func (u *UnitOfWork) Execute(ctx context.Context, fn func() error) error {
 	if err := u.Begin(ctx); err != nil {
 		return err
 	}

--- a/internal/core/application/usecases/auth/login_user.go
+++ b/internal/core/application/usecases/auth/login_user.go
@@ -66,7 +66,7 @@ func (h *LoginUserHandler) Handle(ctx context.Context, cmd LoginUserCommand) (Lo
 	user.MarkLoggedIn()
 
 	// Публикация доменных событий
-	err = h.eventPublisher.PublishDomainEvents(user.GetDomainEvents())
+	err = h.eventPublisher.PublishDomainEvents(ctx, user.GetDomainEvents())
 	if err != nil {
 		return LoginUserResult{}, err
 	}

--- a/internal/core/application/usecases/auth/register_user.go
+++ b/internal/core/application/usecases/auth/register_user.go
@@ -86,13 +86,13 @@ func (h *RegisterUserHandler) Handle(ctx context.Context, cmd RegisterUserComman
 	}
 
 	// Сохранение в транзакции
-	err = h.unitOfWork.Execute(func() error {
+	err = h.unitOfWork.Execute(ctx, func() error {
 		if err := userRepo.Create(&user); err != nil {
 			return err
 		}
 
 		// Публикация доменных событий
-		return h.eventPublisher.PublishDomainEvents(user.GetDomainEvents())
+		return h.eventPublisher.PublishDomainEvents(ctx, user.GetDomainEvents())
 	})
 
 	if err != nil {

--- a/internal/core/ports/event_publisher.go
+++ b/internal/core/ports/event_publisher.go
@@ -11,7 +11,7 @@ import (
 type EventPublisher interface {
 	Publish(ctx context.Context, events ...ddd.DomainEvent) error
 	PublishAsync(ctx context.Context, events ...ddd.DomainEvent)
-	PublishDomainEvents(events []ddd.DomainEvent) error
+	PublishDomainEvents(ctx context.Context, events []ddd.DomainEvent) error
 }
 
 // NullEventPublisher is a no-op implementation for development
@@ -36,8 +36,7 @@ func (p *NullEventPublisher) PublishAsync(ctx context.Context, events ...ddd.Dom
 	}
 }
 
-func (p *NullEventPublisher) PublishDomainEvents(events []ddd.DomainEvent) error {
+func (p *NullEventPublisher) PublishDomainEvents(ctx context.Context, events []ddd.DomainEvent) error {
 	// Convert slice to variadic and call Publish
-	ctx := context.Background()
 	return p.Publish(ctx, events...)
 }

--- a/internal/core/ports/unit_of_work.go
+++ b/internal/core/ports/unit_of_work.go
@@ -8,6 +8,6 @@ type UnitOfWork interface {
 	Begin(ctx context.Context) error
 	Commit(ctx context.Context) error
 	Rollback() error
-	Execute(fn func() error) error
+	Execute(ctx context.Context, fn func() error) error
 	UserRepository() UserRepository
 }


### PR DESCRIPTION
## Summary
- Accept context in unit of work `Execute` and propagate to `Begin`/`Commit`
- Pass context to domain event publishing and accept it in interfaces

## Testing
- `go test ./...` *(fails: `google.golang.org/grpc@v1.75.0: Get "https://proxy.golang.org/google.golang.org/grpc/@v/v1.75.0.zip": Forbidden`)*


------
https://chatgpt.com/codex/tasks/task_e_68b89ee3ae388327a3f08b3155017aa5