### PR TITLE
Use slog logger in event repository

### DIFF
--- a/internal/adapters/out/postgres/eventrepo/repository.go
+++ b/internal/adapters/out/postgres/eventrepo/repository.go
@@ -2,7 +2,7 @@ package eventrepo
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -64,12 +64,12 @@ func (r *Repository) PublishAsync(ctx context.Context, events ...ddd.DomainEvent
 
 		tracker, err := r.trackerFactory()
 		if err != nil {
-			log.Printf("ERROR: Failed to create tracker for event publishing: %v", err)
+			slog.Error("Failed to create tracker for event publishing", slog.Any("error", err))
 			return
 		}
 
 		if err := r.publishWithTracker(ctx, tracker, events...); err != nil {
-			log.Printf("ERROR: Failed to publish events: %v", err)
+			slog.Error("Failed to publish events", slog.Any("error", err))
 		}
 	}()
 }


### PR DESCRIPTION
## Summary
- replace legacy log.Printf with Go's structured slog logger in event repository

## Testing
- `go test ./...` *(fails: command hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a0530c7083278f3e10f04ca522b1