### PR TITLE
refactor: isolate HTTP error converters

### DIFF
--- a/internal/adapters/in/http/httperrs/http_converter.go
+++ b/internal/adapters/in/http/httperrs/http_converter.go
@@ -1,10 +1,11 @@
-package errs
+package httperrs
 
 import (
 	"errors"
 	"net/http"
 
 	"quest-auth/internal/generated/servers"
+	errs "quest-auth/internal/pkg/errs"
 )
 
 // HTTPError represents a structured HTTP error response
@@ -33,7 +34,7 @@ func ToHTTP(err error) HTTPError {
 	}
 
 	// Check for domain validation errors
-	var domainValidationErr *DomainValidationError
+	var domainValidationErr *errs.DomainValidationError
 	if errors.As(err, &domainValidationErr) {
 		switch domainValidationErr.Field {
 		case "email":
@@ -90,7 +91,7 @@ func ToHTTP(err error) HTTPError {
 	}
 
 	// Check for not found errors
-	var notFoundErr *NotFoundError
+	var notFoundErr *errs.NotFoundError
 	if errors.As(err, &notFoundErr) {
 		return HTTPError{
 			Type:       "not-found",

--- a/internal/adapters/in/http/httperrs/http_errors.go
+++ b/internal/adapters/in/http/httperrs/http_errors.go
@@ -1,4 +1,4 @@
-package errs
+package httperrs
 
 import (
 	"fmt"

--- a/internal/adapters/in/http/login_handler.go
+++ b/internal/adapters/in/http/login_handler.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"quest-auth/internal/core/application/usecases/commands"
 
+	"quest-auth/internal/adapters/in/http/httperrs"
 	"quest-auth/internal/adapters/in/http/validations"
 	"quest-auth/internal/generated/servers"
-	"quest-auth/internal/pkg/errs"
 )
 
 // Login implements POST /auth/login from OpenAPI.
@@ -15,7 +15,7 @@ func (a *APIHandler) Login(ctx context.Context, request servers.LoginRequestObje
 	validatedData, validationErr := validations.ValidateLoginUserRequestBody(request.Body)
 	if validationErr != nil {
 		// Use unified error converter
-		return errs.ToLoginResponse(validationErr), nil
+		return httperrs.ToLoginResponse(validationErr), nil
 	}
 
 	// Execute login command
@@ -27,7 +27,7 @@ func (a *APIHandler) Login(ctx context.Context, request servers.LoginRequestObje
 	result, err := a.loginHandler.Handle(ctx, cmd)
 	if err != nil {
 		// Use unified error converter
-		return errs.ToLoginResponse(err), nil
+		return httperrs.ToLoginResponse(err), nil
 	}
 
 	// Map result to response directly

--- a/internal/adapters/in/http/register_handler.go
+++ b/internal/adapters/in/http/register_handler.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"quest-auth/internal/core/application/usecases/commands"
 
+	"quest-auth/internal/adapters/in/http/httperrs"
 	"quest-auth/internal/adapters/in/http/validations"
 	"quest-auth/internal/generated/servers"
-	"quest-auth/internal/pkg/errs"
 )
 
 // Register implements POST /auth/register from OpenAPI.
@@ -15,7 +15,7 @@ func (a *APIHandler) Register(ctx context.Context, request servers.RegisterReque
 	validatedData, validationErr := validations.ValidateRegisterUserRequestBody(request.Body)
 	if validationErr != nil {
 		// Use unified error converter
-		return errs.ToRegisterResponse(validationErr), nil
+		return httperrs.ToRegisterResponse(validationErr), nil
 	}
 
 	// Execute register command
@@ -29,7 +29,7 @@ func (a *APIHandler) Register(ctx context.Context, request servers.RegisterReque
 	result, err := a.registerHandler.Handle(ctx, cmd)
 	if err != nil {
 		// Use unified error converter
-		return errs.ToRegisterResponse(err), nil
+		return httperrs.ToRegisterResponse(err), nil
 	}
 
 	// Map result to response directly


### PR DESCRIPTION
## Summary
- move HTTP error converters to `httperrs` adapter package
- update HTTP handlers to use new converters
- keep `internal/pkg/errs` for domain and infrastructure errors only

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68badfb5058c8327b73f453d412cbbe0