### PR TITLE
refactor: inject password hashing and clock ports

### DIFF
--- a/internal/adapters/out/bcrypt/hasher.go
+++ b/internal/adapters/out/bcrypt/hasher.go
@@ -1,0 +1,29 @@
+package bcryptadapter
+
+import (
+	gobcrypt "golang.org/x/crypto/bcrypt"
+	"quest-auth/internal/core/ports"
+)
+
+// Hasher implements PasswordHasher using bcrypt.
+type Hasher struct{}
+
+func NewHasher() *Hasher {
+	return &Hasher{}
+}
+
+// Hash generates bcrypt hash for the given password.
+func (h *Hasher) Hash(raw string) (string, error) {
+	b, err := gobcrypt.GenerateFromPassword([]byte(raw), gobcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// Compare checks whether given hash matches raw password.
+func (h *Hasher) Compare(hash, raw string) bool {
+	return gobcrypt.CompareHashAndPassword([]byte(hash), []byte(raw)) == nil
+}
+
+var _ ports.PasswordHasher = (*Hasher)(nil)

--- a/internal/adapters/out/time/clock.go
+++ b/internal/adapters/out/time/clock.go
@@ -1,0 +1,20 @@
+package timeadapter
+
+import (
+	"quest-auth/internal/core/ports"
+	stdtime "time"
+)
+
+// Clock implements ports.Clock using the system time.
+type Clock struct{}
+
+func NewClock() *Clock {
+	return &Clock{}
+}
+
+// Now returns current time.
+func (c *Clock) Now() stdtime.Time {
+	return stdtime.Now()
+}
+
+var _ ports.Clock = (*Clock)(nil)

--- a/internal/core/application/usecases/commands/register_user_handler.go
+++ b/internal/core/application/usecases/commands/register_user_handler.go
@@ -14,17 +14,23 @@ type RegisterUserHandler struct {
 	unitOfWork     ports.UnitOfWork
 	eventPublisher ports.EventPublisher
 	jwtService     ports.JWTService
+	passwordHasher ports.PasswordHasher
+	clock          ports.Clock
 }
 
 func NewRegisterUserHandler(
 	unitOfWork ports.UnitOfWork,
 	eventPublisher ports.EventPublisher,
 	jwtService ports.JWTService,
+	passwordHasher ports.PasswordHasher,
+	clock ports.Clock,
 ) *RegisterUserHandler {
 	return &RegisterUserHandler{
 		unitOfWork:     unitOfWork,
 		eventPublisher: eventPublisher,
 		jwtService:     jwtService,
+		passwordHasher: passwordHasher,
+		clock:          clock,
 	}
 }
 
@@ -63,7 +69,7 @@ func (h *RegisterUserHandler) Handle(ctx context.Context, cmd RegisterUserComman
 	}
 
 	// Создание доменного объекта User
-	user, err := auth.NewUser(email, phone, cmd.Name, cmd.Password)
+	user, err := auth.NewUser(email, phone, cmd.Name, cmd.Password, h.passwordHasher, h.clock)
 	if err != nil {
 		return RegisterUserResult{}, errs.NewDomainValidationError("user", err.Error())
 	}

--- a/internal/core/domain/model/auth/events.go
+++ b/internal/core/domain/model/auth/events.go
@@ -17,13 +17,13 @@ type UserRegistered struct {
 	At     time.Time
 }
 
-func NewUserRegistered(userID uuid.UUID, email, phone string) UserRegistered {
+func NewUserRegistered(userID uuid.UUID, email, phone string, at time.Time) UserRegistered {
 	return UserRegistered{
 		ID:     uuid.New(),
 		UserID: userID,
 		Email:  email,
 		Phone:  phone,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 
@@ -39,13 +39,13 @@ type UserPhoneChanged struct {
 	At     time.Time
 }
 
-func NewUserPhoneChanged(userID uuid.UUID, old, new string) UserPhoneChanged {
+func NewUserPhoneChanged(userID uuid.UUID, old, new string, at time.Time) UserPhoneChanged {
 	return UserPhoneChanged{
 		ID:     uuid.New(),
 		UserID: userID,
 		Old:    old,
 		New:    new,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 
@@ -61,13 +61,13 @@ type UserNameChanged struct {
 	At     time.Time
 }
 
-func NewUserNameChanged(userID uuid.UUID, old, new string) UserNameChanged {
+func NewUserNameChanged(userID uuid.UUID, old, new string, at time.Time) UserNameChanged {
 	return UserNameChanged{
 		ID:     uuid.New(),
 		UserID: userID,
 		Old:    old,
 		New:    new,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 
@@ -81,11 +81,11 @@ type UserPasswordChanged struct {
 	At     time.Time
 }
 
-func NewUserPasswordChanged(userID uuid.UUID) UserPasswordChanged {
+func NewUserPasswordChanged(userID uuid.UUID, at time.Time) UserPasswordChanged {
 	return UserPasswordChanged{
 		ID:     uuid.New(),
 		UserID: userID,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 

--- a/internal/core/ports/clock.go
+++ b/internal/core/ports/clock.go
@@ -1,0 +1,8 @@
+package ports
+
+import "time"
+
+// Clock provides current time.
+type Clock interface {
+	Now() time.Time
+}

--- a/internal/core/ports/password_hasher.go
+++ b/internal/core/ports/password_hasher.go
@@ -1,0 +1,9 @@
+package ports
+
+// PasswordHasher provides methods for hashing and comparing passwords.
+type PasswordHasher interface {
+	// Hash generates a hash for the given raw password.
+	Hash(raw string) (string, error)
+	// Compare checks whether the provided raw password matches the given hash.
+	Compare(hash, raw string) bool
+}

--- a/tests/integration/core/test_container.go
+++ b/tests/integration/core/test_container.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"quest-auth/cmd"
+	bcryptadapter "quest-auth/internal/adapters/out/bcrypt"
 	"quest-auth/internal/adapters/out/jwt"
 	"quest-auth/internal/adapters/out/postgres"
+	timeadapter "quest-auth/internal/adapters/out/time"
 	"quest-auth/internal/core/application/usecases/commands"
 	"quest-auth/internal/core/ports"
 
@@ -107,9 +109,13 @@ func NewTestDIContainer(suiteContainer SuiteDIContainer) TestDIContainer {
 		time.Duration(testConfig.JWTRefreshTokenDuration)*time.Hour,
 	)
 
+	// Password hasher and clock
+	passwordHasher := bcryptadapter.NewHasher()
+	clock := timeadapter.NewClock()
+
 	// Создание обработчиков use cases
-	loginUserHandler := commands.NewLoginUserHandler(unitOfWork, eventPublisher, jwtService)
-	registerUserHandler := commands.NewRegisterUserHandler(unitOfWork, eventPublisher, jwtService)
+	loginUserHandler := commands.NewLoginUserHandler(unitOfWork, eventPublisher, jwtService, passwordHasher, clock)
+	registerUserHandler := commands.NewRegisterUserHandler(unitOfWork, eventPublisher, jwtService, passwordHasher, clock)
 
 	// Create HTTP Router for API testing
 	compositionRoot := cmd.NewCompositionRoot(testConfig, db)


### PR DESCRIPTION
## Summary
- add `PasswordHasher` and `Clock` ports and implement bcrypt/time adapters
- refactor auth domain and handlers to consume hasher and clock interfaces
- wire new ports in composition root and tests

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68badfc37b608327ad67225fb89c6644