### PR TITLE
Introduce clock abstraction for time-dependent operations

### DIFF
--- a/internal/adapters/out/clock/clock.go
+++ b/internal/adapters/out/clock/clock.go
@@ -1,0 +1,22 @@
+package clock
+
+import (
+	"time"
+
+	clockpkg "quest-auth/internal/pkg/clock"
+)
+
+// SystemClock implements clock.Clock using the system time.
+type SystemClock struct{}
+
+func NewSystemClock() *SystemClock {
+	return &SystemClock{}
+}
+
+// Now returns current system time.
+func (c *SystemClock) Now() time.Time {
+	return time.Now()
+}
+
+// Compile-time check that SystemClock implements clock.Clock
+var _ clockpkg.Clock = (*SystemClock)(nil)

--- a/internal/core/application/usecases/commands/login_user_handler.go
+++ b/internal/core/application/usecases/commands/login_user_handler.go
@@ -5,6 +5,7 @@ import (
 
 	"quest-auth/internal/core/domain/model/kernel"
 	"quest-auth/internal/core/ports"
+	clockpkg "quest-auth/internal/pkg/clock"
 	"quest-auth/internal/pkg/errs"
 )
 
@@ -13,17 +14,20 @@ type LoginUserHandler struct {
 	unitOfWork     ports.UnitOfWork
 	eventPublisher ports.EventPublisher
 	jwtService     ports.JWTService
+	clock          clockpkg.Clock
 }
 
 func NewLoginUserHandler(
 	unitOfWork ports.UnitOfWork,
 	eventPublisher ports.EventPublisher,
 	jwtService ports.JWTService,
+	clock clockpkg.Clock,
 ) *LoginUserHandler {
 	return &LoginUserHandler{
 		unitOfWork:     unitOfWork,
 		eventPublisher: eventPublisher,
 		jwtService:     jwtService,
+		clock:          clock,
 	}
 }
 
@@ -48,7 +52,7 @@ func (h *LoginUserHandler) Handle(ctx context.Context, cmd LoginUserCommand) (Lo
 	}
 
 	// Отметка о входе (создание доменного события)
-	user.MarkLoggedIn()
+	user.MarkLoggedIn(h.clock)
 
 	// Публикация доменных событий
 	err = h.eventPublisher.PublishDomainEvents(ctx, user.GetDomainEvents())

--- a/internal/core/application/usecases/commands/register_user_handler.go
+++ b/internal/core/application/usecases/commands/register_user_handler.go
@@ -6,6 +6,7 @@ import (
 	"quest-auth/internal/core/domain/model/auth"
 	"quest-auth/internal/core/domain/model/kernel"
 	"quest-auth/internal/core/ports"
+	clockpkg "quest-auth/internal/pkg/clock"
 	"quest-auth/internal/pkg/errs"
 )
 
@@ -14,17 +15,20 @@ type RegisterUserHandler struct {
 	unitOfWork     ports.UnitOfWork
 	eventPublisher ports.EventPublisher
 	jwtService     ports.JWTService
+	clock          clockpkg.Clock
 }
 
 func NewRegisterUserHandler(
 	unitOfWork ports.UnitOfWork,
 	eventPublisher ports.EventPublisher,
 	jwtService ports.JWTService,
+	clock clockpkg.Clock,
 ) *RegisterUserHandler {
 	return &RegisterUserHandler{
 		unitOfWork:     unitOfWork,
 		eventPublisher: eventPublisher,
 		jwtService:     jwtService,
+		clock:          clock,
 	}
 }
 
@@ -63,7 +67,7 @@ func (h *RegisterUserHandler) Handle(ctx context.Context, cmd RegisterUserComman
 	}
 
 	// Создание доменного объекта User
-	user, err := auth.NewUser(email, phone, cmd.Name, cmd.Password)
+	user, err := auth.NewUser(h.clock, email, phone, cmd.Name, cmd.Password)
 	if err != nil {
 		return RegisterUserResult{}, errs.NewDomainValidationError("user", err.Error())
 	}

--- a/internal/core/domain/model/auth/events.go
+++ b/internal/core/domain/model/auth/events.go
@@ -17,13 +17,14 @@ type UserRegistered struct {
 	At     time.Time
 }
 
-func NewUserRegistered(userID uuid.UUID, email, phone string) UserRegistered {
+// NewUserRegistered creates UserRegistered domain event at the specified time.
+func NewUserRegistered(userID uuid.UUID, email, phone string, at time.Time) UserRegistered {
 	return UserRegistered{
 		ID:     uuid.New(),
 		UserID: userID,
 		Email:  email,
 		Phone:  phone,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 
@@ -39,13 +40,14 @@ type UserPhoneChanged struct {
 	At     time.Time
 }
 
-func NewUserPhoneChanged(userID uuid.UUID, old, new string) UserPhoneChanged {
+// NewUserPhoneChanged creates UserPhoneChanged event at the given time.
+func NewUserPhoneChanged(userID uuid.UUID, old, new string, at time.Time) UserPhoneChanged {
 	return UserPhoneChanged{
 		ID:     uuid.New(),
 		UserID: userID,
 		Old:    old,
 		New:    new,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 
@@ -61,13 +63,14 @@ type UserNameChanged struct {
 	At     time.Time
 }
 
-func NewUserNameChanged(userID uuid.UUID, old, new string) UserNameChanged {
+// NewUserNameChanged creates UserNameChanged event at the specified time.
+func NewUserNameChanged(userID uuid.UUID, old, new string, at time.Time) UserNameChanged {
 	return UserNameChanged{
 		ID:     uuid.New(),
 		UserID: userID,
 		Old:    old,
 		New:    new,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 
@@ -81,11 +84,12 @@ type UserPasswordChanged struct {
 	At     time.Time
 }
 
-func NewUserPasswordChanged(userID uuid.UUID) UserPasswordChanged {
+// NewUserPasswordChanged creates UserPasswordChanged event at the given time.
+func NewUserPasswordChanged(userID uuid.UUID, at time.Time) UserPasswordChanged {
 	return UserPasswordChanged{
 		ID:     uuid.New(),
 		UserID: userID,
-		At:     time.Now(),
+		At:     at,
 	}
 }
 

--- a/internal/pkg/clock/clock.go
+++ b/internal/pkg/clock/clock.go
@@ -1,0 +1,8 @@
+package clock
+
+import "time"
+
+// Clock provides current time abstraction.
+type Clock interface {
+	Now() time.Time
+}

--- a/tests/integration/core/test_container.go
+++ b/tests/integration/core/test_container.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"quest-auth/cmd"
+	clockadapter "quest-auth/internal/adapters/out/clock"
 	"quest-auth/internal/adapters/out/jwt"
 	"quest-auth/internal/adapters/out/postgres"
 	"quest-auth/internal/core/application/usecases/commands"
@@ -108,8 +109,9 @@ func NewTestDIContainer(suiteContainer SuiteDIContainer) TestDIContainer {
 	)
 
 	// Создание обработчиков use cases
-	loginUserHandler := commands.NewLoginUserHandler(unitOfWork, eventPublisher, jwtService)
-	registerUserHandler := commands.NewRegisterUserHandler(unitOfWork, eventPublisher, jwtService)
+	clock := clockadapter.NewSystemClock()
+	loginUserHandler := commands.NewLoginUserHandler(unitOfWork, eventPublisher, jwtService, clock)
+	registerUserHandler := commands.NewRegisterUserHandler(unitOfWork, eventPublisher, jwtService, clock)
 
 	// Create HTTP Router for API testing
 	compositionRoot := cmd.NewCompositionRoot(testConfig, db)


### PR DESCRIPTION
## Summary
- add `clock.Clock` interface and system clock adapter
- inject clock into domain, usecases, and composition root
- update tests and domain events to accept explicit time

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68badfd417648327a6ee6251a53bdaa0