### PR TITLE
Preserve user info in refreshed JWT tokens

### DIFF
--- a/internal/adapters/out/jwt/service.go
+++ b/internal/adapters/out/jwt/service.go
@@ -64,9 +64,12 @@ func (s *Service) GenerateTokenPair(userID uuid.UUID, email, name, phone string,
 
 	// Refresh token (PII не обязательно)
 	refreshClaims := &Claims{
-		UserID: userID,
-		Email:  email,
-		Type:   "refresh",
+		UserID:    userID,
+		Email:     email,
+		Name:      name,
+		Phone:     phone,
+		CreatedAt: createdAt.Unix(),
+		Type:      "refresh",
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.refreshTokenDuration)),
 			IssuedAt:  jwt.NewNumericDate(now),

--- a/internal/adapters/out/jwt/service_test.go
+++ b/internal/adapters/out/jwt/service_test.go
@@ -1,0 +1,45 @@
+package jwt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestRefreshTokensPreservesClaims(t *testing.T) {
+	service := NewService("secret", time.Minute, time.Hour)
+
+	userID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+	email := "user@example.com"
+	name := "John Doe"
+	phone := "+1234567890"
+	createdAt := time.Unix(1700000000, 0).UTC()
+
+	pair, err := service.GenerateTokenPair(userID, email, name, phone, createdAt)
+	if err != nil {
+		t.Fatalf("GenerateTokenPair() error = %v", err)
+	}
+
+	refreshedPair, err := service.RefreshTokens(pair.RefreshToken)
+	if err != nil {
+		t.Fatalf("RefreshTokens() error = %v", err)
+	}
+
+	claims, err := service.ValidateAccessToken(refreshedPair.AccessToken)
+	if err != nil {
+		t.Fatalf("ValidateAccessToken() error = %v", err)
+	}
+
+	if claims.Name != name {
+		t.Fatalf("expected name %q, got %q", name, claims.Name)
+	}
+
+	if claims.Phone != phone {
+		t.Fatalf("expected phone %q, got %q", phone, claims.Phone)
+	}
+
+	if !claims.CreatedAt.Equal(createdAt) {
+		t.Fatalf("expected createdAt %v, got %v", createdAt, claims.CreatedAt)
+	}
+}


### PR DESCRIPTION
## Summary
- store the user's name, phone and creation timestamp in refresh token claims before generating a new token pair
- add unit coverage to ensure refreshed access tokens keep the original user metadata

## Testing
- go test ./... *(fails: module downloads are forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f6a81d08327826e0e201dbb52d5